### PR TITLE
런타인 OpenAI 클라이언트 설정 도입 및 적용

### DIFF
--- a/src/main/java/com/cdbd/opensource/OpensourceApplication.java
+++ b/src/main/java/com/cdbd/opensource/OpensourceApplication.java
@@ -1,9 +1,12 @@
 package com.cdbd.opensource;
 
+import com.cdbd.opensource.infrastructure.llm.AiDefaultsProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
+@EnableConfigurationProperties(AiDefaultsProperties.class)
 public class OpensourceApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/cdbd/opensource/infrastructure/llm/AiDefaultsProperties.java
+++ b/src/main/java/com/cdbd/opensource/infrastructure/llm/AiDefaultsProperties.java
@@ -1,0 +1,23 @@
+package com.cdbd.opensource.infrastructure.llm;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@ConfigurationProperties(prefix = "spring.ai.openai")
+public record AiDefaultsProperties(
+    String baseUrl,
+    String apiKey,
+    Chat chat
+) {
+
+  public record Chat(Options options) { }
+
+  public record Options(
+      String model,
+      Integer maxTokens,
+      Double temperature,
+      Double presencePenalty,
+      Double frequencyPenalty
+  ) { }
+}

--- a/src/main/java/com/cdbd/opensource/infrastructure/llm/AiRuntimeManager.java
+++ b/src/main/java/com/cdbd/opensource/infrastructure/llm/AiRuntimeManager.java
@@ -33,6 +33,11 @@ public class AiRuntimeManager {
 
   public ChatClient client() { return clientRef.get(); }
 
+  public synchronized void applyUserInputs(String apiKey, Integer maxTokens, Double temperature) {
+    var merged = settingsRef.get().mergeUserInputs(apiKey, maxTokens, temperature);
+    apply(merged);
+  }
+
   private void apply(AiRuntimeSettings s) {
     OpenAiApi api = OpenAiApi.builder().baseUrl(s.baseUrl()).apiKey(s.apiKey()).build();
     OpenAiChatOptions options = OpenAiChatOptions.builder()

--- a/src/main/java/com/cdbd/opensource/infrastructure/llm/AiRuntimeManager.java
+++ b/src/main/java/com/cdbd/opensource/infrastructure/llm/AiRuntimeManager.java
@@ -1,0 +1,54 @@
+package com.cdbd.opensource.infrastructure.llm;
+
+import com.cdbd.opensource.infrastructure.llm.AiDefaultsProperties.Options;
+import java.util.concurrent.atomic.AtomicReference;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@EnableConfigurationProperties(AiDefaultsProperties.class)
+public class AiRuntimeManager {
+
+  private final AtomicReference<AiRuntimeSettings> settingsRef = new AtomicReference<>();
+  private final AtomicReference<ChatClient> clientRef = new AtomicReference<>();
+
+  public AiRuntimeManager(AiDefaultsProperties aiDefaultsProperties) {
+    AiDefaultsProperties.Options opt = aiDefaultsProperties.chat().options();
+    apply(new AiRuntimeSettings(
+        aiDefaultsProperties.baseUrl(),
+        aiDefaultsProperties.apiKey(),
+        opt.model(),
+        opt.maxTokens() ,
+        opt.temperature(),
+        opt.presencePenalty(),
+        opt.frequencyPenalty()
+    ));
+  }
+
+  public AiRuntimeSettings current() { return settingsRef.get(); }
+
+  public ChatClient client() { return clientRef.get(); }
+
+  private void apply(AiRuntimeSettings s) {
+    OpenAiApi api = OpenAiApi.builder().baseUrl(s.baseUrl()).apiKey(s.apiKey()).build();
+    OpenAiChatOptions options = OpenAiChatOptions.builder()
+        .model(s.model())
+        .temperature(s.temperature())
+        .maxTokens(s.maxTokens())
+        .presencePenalty(s.presencePenalty())
+        .frequencyPenalty(s.frequencyPenalty())
+        .build();
+
+    OpenAiChatModel model = OpenAiChatModel.builder().openAiApi(api).defaultOptions(options).build();
+    ChatClient newClient = ChatClient.builder(model)
+        .defaultOptions(options)
+        .build();
+
+    clientRef.set(newClient);
+    settingsRef.set(s);
+  }
+}

--- a/src/main/java/com/cdbd/opensource/infrastructure/llm/AiRuntimeSettings.java
+++ b/src/main/java/com/cdbd/opensource/infrastructure/llm/AiRuntimeSettings.java
@@ -1,0 +1,34 @@
+package com.cdbd.opensource.infrastructure.llm;
+
+public record AiRuntimeSettings(
+    String baseUrl,
+    String apiKey,
+    String model,
+    Integer maxTokens,
+    Double temperature,
+    Double presencePenalty,
+    Double frequencyPenalty
+) {
+  public AiRuntimeSettings mergeUserInputs(
+      String newApiKey, Integer newMaxTokens, Double newTemperature) {
+    return new AiRuntimeSettings(
+        baseUrl,
+        (newApiKey != null && !newApiKey.isBlank()) ? newApiKey : apiKey,
+        model,
+        newMaxTokens != null ? newMaxTokens : maxTokens,
+        newTemperature != null ? newTemperature : temperature,
+        presencePenalty,
+        frequencyPenalty
+    );
+  }
+
+  public String maskedApiKey() {
+    if (apiKey == null || apiKey.isBlank()) return "";
+    return "****" + apiKey.substring(Math.max(0, apiKey.length() - 4));
+  }
+
+  @Override public String toString() {
+    return "AiRuntimeSettings{baseUrl=%s, apiKey=****, model=%s, maxTokens=%s, temperature=%s, presencePenalty=%s, frequencyPenalty=%s}"
+        .formatted(baseUrl, model, maxTokens, temperature, presencePenalty, frequencyPenalty);
+  }
+}

--- a/src/main/java/com/cdbd/opensource/infrastructure/llm/LLMClient.java
+++ b/src/main/java/com/cdbd/opensource/infrastructure/llm/LLMClient.java
@@ -14,15 +14,15 @@ import org.springframework.stereotype.Component;
 @Component
 public class LLMClient {
 
-  private final ChatClient chatClient;
+  private final AiRuntimeManager runtime;
   private final ObjectMapper objectMapper;
   private final PromptTemplate promptTemplate;
 
   public LLMClient(
-      ChatClient chatClient,
+      AiRuntimeManager runtime,
       ObjectMapper objectMapper,
       @Value("classpath:/prompts/analyze-event-log.txt") Resource promptResource) {
-    this.chatClient = chatClient;
+    this.runtime = runtime;
     this.objectMapper = objectMapper;
     this.promptTemplate = new PromptTemplate(promptResource);
   }
@@ -31,7 +31,7 @@ public class LLMClient {
     try {
       String userMessage = objectMapper.writeValueAsString(eventLog);
       Prompt prompt = promptTemplate.create(Map.of("userMessage", userMessage));
-      String result = chatClient.prompt(prompt).call().content();
+      String result = runtime.client().prompt(prompt).call().content();
       return new LLMResult(result);
 
     } catch (JsonProcessingException e) {

--- a/src/main/java/com/cdbd/opensource/presentation/AiController.java
+++ b/src/main/java/com/cdbd/opensource/presentation/AiController.java
@@ -1,0 +1,37 @@
+package com.cdbd.opensource.presentation;
+
+import com.cdbd.opensource.infrastructure.llm.AiRuntimeManager;
+import com.cdbd.opensource.infrastructure.llm.AiRuntimeSettings;
+import com.cdbd.opensource.presentation.dto.AiSettingsRequest;
+import com.cdbd.opensource.presentation.dto.AiSettingsResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/admin/ai-settings")
+public class AiController {
+
+  private final AiRuntimeManager manager;
+
+  public AiController(AiRuntimeManager manager) {
+    this.manager = manager;
+  }
+
+  @GetMapping
+  public ResponseEntity<AiSettingsResponse> getSettings() {
+    AiRuntimeSettings s = manager.current();
+    return ResponseEntity.ok(
+        new AiSettingsResponse(s.maskedApiKey(), s.maxTokens(), s.temperature()));
+  }
+
+  @PutMapping
+  public ResponseEntity<Void> updateSettings(@RequestBody AiSettingsRequest req) {
+    manager.applyUserInputs(req.apiKey(), req.maxOutputTokens(), req.temperature());
+    return ResponseEntity.ok().build();
+  }
+
+}

--- a/src/main/java/com/cdbd/opensource/presentation/dto/AiSettingsRequest.java
+++ b/src/main/java/com/cdbd/opensource/presentation/dto/AiSettingsRequest.java
@@ -1,0 +1,7 @@
+package com.cdbd.opensource.presentation.dto;
+
+public record AiSettingsRequest(
+    String apiKey,
+    Integer maxOutputTokens,
+    Double temperature
+) { }

--- a/src/main/java/com/cdbd/opensource/presentation/dto/AiSettingsResponse.java
+++ b/src/main/java/com/cdbd/opensource/presentation/dto/AiSettingsResponse.java
@@ -2,6 +2,6 @@ package com.cdbd.opensource.presentation.dto;
 
 public record AiSettingsResponse(
     String apiKeyMasked,
-    String maxOutPutTokens,
+    Integer maxOutPutTokens,
     Double temperature
 ) { }

--- a/src/main/java/com/cdbd/opensource/presentation/dto/AiSettingsResponse.java
+++ b/src/main/java/com/cdbd/opensource/presentation/dto/AiSettingsResponse.java
@@ -1,0 +1,7 @@
+package com.cdbd.opensource.presentation.dto;
+
+public record AiSettingsResponse(
+    String apiKeyMasked,
+    String maxOutPutTokens,
+    Double temperature
+) { }


### PR DESCRIPTION
### 개요
UI에서 입력한 API Key / maxTokens / temperature를 저장 즉시 반영하도록, OpenAI 클라이언트를 런타임에 재구성(hot-swap)하는 기능을 추가했습니다.
저장 전에는 `application.yml`의 `spring.ai.openai.*` 값을 기본값으로 사용합니다.

### 주요 변경 사항
1) 설정 바인딩
    - `AiDefaultsProperties` 추가 (`@ConfigurationProperties(prefix="spring.ai.openai")`)
       - `baseUrl`, `apiKey`, `chat.options(model, maxTokens, temperature, presencePenalty, frequencyPenalty)`를 yml에서 바인딩
     - `OpensourceApplication`에 `@EnableConfigurationProperties(AiDefaultsProperties.class)` 추가

2) 런타임 설정/클라이언트 매니저
- `AiRuntimeSettings` (불변 record)
   - `mergeUserInputs(apiKey, maxTokens, temperature)`, `maskedApiKey()` 제공
- `AiRuntimeManager`
   - 앱 기동 시 yml 기본값으로 초기화
   - `applyUserInputs(apiKey, maxTokens, temperature)` 호출 시
      - `OpenAiApi.builder()` + `OpenAiChatOptions.builder()` + `OpenAiChatModel.builder()`로 새 인스턴스 생성
      - `AtomicReference`로 원자적 교체(무중단)

3) 서비스 적용
- `LLMClient`가 더 이상 직접 `ChatClient` 빈을 들고 있지 않고,
항상 `AiRuntimeManager.client()`에서 최신 클라이언트를 조회하여 호출

4) 관리용 REST API
- `AiController` (`/api/v1/admin/ai-settings`)
   - `GET` 현재 설정 조회(키 마스킹)
   - `PUT `사용자 입력값 저장 → 즉시 반영
- DTO 추가
   - `AiSettingsRequest(apiKey, maxOutputTokens, temperature)`
   - `AiSettingsResponse(apiKeyMasked, maxOutPutTokens, temperature)`

### 의사 결정 흐름
1. 목표
    - 저장 버튼 클릭 시 서버 재기동 없이 모델 옵션을 바꾸고, 이후 호출부터 즉시 적용
    - 저장 전에는 `spring.ai.openai.*`의 기본값을 사용
2. 대안 검토
    - (폐기) 빈 재등록 / 컨텍스트 리프레시: 복잡하고 리스크 큼 (의존 그래프 재결선, 순간 정지 가능성)
    - (선택) Cloud Config + `@RefreshScope`: 무중단 구성 변경은 좋지만 인프라 공수가 큼
    - (채택) 참조 스왑(AtomicReference)
       - 새로운 `OpenAiApi/OpenAiChatModel/ChatClient`를 새로 만들고 원자적으로 교체
       - 진행 중 요청은 구 인스턴스로 완료, 새 요청부터 신 인스턴스 사용 → 무중단/스레드 안전
3. 설계 포인트
     - 단일 책임 분리: 런타임 설정/클라이언트 생명주기는 `AiRuntimeManager`가 관리, 호출 로직은 `LLMClient`
     - 불변 + 원자 교체: 레이스 컨디션 최소화, 고부하 환경에서 읽기는 락 없이 빠르게
     - 보안: 키는 응답에서 마스킹 노출

### 관련 이슈
ISSUE #15 

### 후속 작업 필요
ISSUE #16 